### PR TITLE
Handle unicode strings

### DIFF
--- a/meld3/__init__.py
+++ b/meld3/__init__.py
@@ -20,6 +20,7 @@ from ._compat import _b
 from ._compat import _raise_serialization_error
 from ._compat import _encode_entity
 from ._compat import fixtag
+from ._compat import string_types
 
 AUTOCLOSE = "p", "li", "tr", "th", "td", "head", "body"
 IGNOREEND = "img", "hr", "meta", "link", "br"
@@ -521,9 +522,9 @@ class _MeldElementInterface:
         """ Set attributes on this node. """
         for k, v in kw.items():
             # prevent this from getting to the parser if possible
-            if not isinstance(k, str):
+            if not isinstance(k, string_types):
                 raise ValueError('do not set non-stringtype as key: %s' % k)
-            if not isinstance(v, str):
+            if not isinstance(v, string_types):
                 raise ValueError('do not set non-stringtype as val: %s' % v)
             self.attrib[k] = kw[k]
 

--- a/meld3/__init__.py
+++ b/meld3/__init__.py
@@ -1132,7 +1132,10 @@ def _escape_attrib(text, encoding):
         encoded = encoded.replace(_QUOTE, _QUOTE_ESCAPED)
         return encoded
     except (TypeError, AttributeError):
-        _raise_serialization_error(text)
+        if text is None:
+            return ''
+        else:
+            _raise_serialization_error(text)
 
 # utility functions
 

--- a/meld3/_compat.py
+++ b/meld3/_compat.py
@@ -45,6 +45,12 @@ else:               # Python 2.x
     def _u(x, encoding='latin1'):
         # x shoulr be a str literal
         return unicode(x, encoding)
+try:
+    from types import StringTypes
+    string_types = StringTypes
+
+except ImportError:  # Python 3.x
+    string_types = str
 
 #-----------------------------------------------------------------------------
 # Begin fork from Python 2.6.8 stdlib:

--- a/meld3/test_meld3.py
+++ b/meld3/test_meld3.py
@@ -480,10 +480,10 @@ class MeldAPITests(unittest.TestCase):
         from . import _MELD_ID
         root = self._makeElement(_COMPLEX_XHTML)
         D = root.findmeld('form1')
-        D.attributes(foo='bar', baz='1', g='2', action='#')
+        D.attributes(foo='bar', baz='1', g='2', action=u'#')
         self.assertEqual(D.attrib, {
             'foo':'bar', 'baz':'1', 'g':'2',
-            'method':'POST', 'action':'#',
+            'method':'POST', 'action':u'#',
             _MELD_ID: 'form1'})
 
     def test_attributes_nonstringtype_raises(self):


### PR DESCRIPTION
The base distribution of meld3 chokes on unicode strings. 