### PR TITLE
Drop support for EOL Python and to match Supervisor 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,8 @@ language: python
 sudo: false
 matrix:
     include:
-        - python: 2.6
-          env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27
-        - python: 3.2
-          env: TOXENV=py32
-        - python: 3.3
-          env: TOXENV=py33
         - python: 3.4
           env: TOXENV=py34
         - python: 3.5
@@ -19,7 +13,6 @@ matrix:
         - python: 3.6
           env: TOXENV=py36
 install:
-    # "virtualenv<14.0.0" is needed for Python 3.2 compat
-    - travis_retry pip install "virtualenv<14.0.0" tox
+    - travis_retry pip install virtualenv tox
 script:
     - travis_retry tox

--- a/README.txt
+++ b/README.txt
@@ -17,9 +17,9 @@ Overview
 
 Requirements
 
-  On Python 3, meld3 requires Python 3.2 or later.
+  On Python 3, meld3 requires Python 3.4 or later.
 
-  On Python 2, meld3 requires Python 2.5 or later.
+  On Python 2, meld3 requires Python 2.7.
 
 Installation
 

--- a/meld3/__init__.py
+++ b/meld3/__init__.py
@@ -132,7 +132,7 @@ helper = PyHelper()
 _MELD_NS_URL  = 'http://www.plope.com/software/meld3'
 _MELD_PREFIX  = '{%s}' % _MELD_NS_URL
 _MELD_LOCAL   = 'id'
-_MELD_ID      = '%s%s' % (_MELD_PREFIX, _MELD_LOCAL)
+_MELD_ID      = '{}{}'.format(_MELD_PREFIX, _MELD_LOCAL)
 _MELD_SHORT_ID = 'meld:%s' % _MELD_LOCAL
 _XHTML_NS_URL = 'http://www.w3.org/1999/xhtml'
 _XHTML_PREFIX = '{%s}' % _XHTML_NS_URL
@@ -166,7 +166,7 @@ class _MeldElementInterface:
         self._children = []
 
     def __repr__(self):
-        return "<MeldElement %s at %x>" % (self.tag, id(self))
+        return "<MeldElement {} at {:x}>".format(self.tag, id(self))
 
     def __len__(self):
         return len(self._children)
@@ -778,7 +778,7 @@ class HTMLMeldParser(HTMLParser):
             if http_equiv == "content-type" and content:
                 # use email to parse the http header
                 msg = email.message_from_string(
-                    "%s: %s\n\n" % (http_equiv, content)
+                    "{}: {}\n\n".format(http_equiv, content)
                     )
                 encoding = msg.get_param("charset")
                 if encoding:

--- a/meld3/__init__.py
+++ b/meld3/__init__.py
@@ -1,6 +1,5 @@
 import email
 import re
-import sys
 
 from xml.etree.ElementTree import Comment
 from xml.etree.ElementTree import ElementPath
@@ -14,7 +13,6 @@ from ._compat import htmlentitydefs
 from ._compat import HTMLParser
 from ._compat import StringIO
 from ._compat import StringTypes
-from ._compat import bytes
 from ._compat import unichr
 from ._compat import _u
 from ._compat import _b
@@ -742,27 +740,6 @@ class MeldTreeBuilder(TreeBuilder):
     def doctype(self, name, pubid, system):
         pass
 
-if sys.version_info < (2, 7):
-    class MeldParser(XMLParser):
-
-        """ Based on Fredrik's PIParser[1]
-
-        Blithely ignores the case of a comment existing outside the root
-        element, and ignores processing instructions entirely.
-
-        [1] http://effbot.org/zone/element-pi.htm.
-        """
-        def __init__(self, html=0, target=None):
-            XMLParser.__init__(self, html, target)
-            self._parser.CommentHandler = self.handle_comment
-
-        def handle_comment(self, data):
-            self._target.start(Comment, {})
-            self._target.data(data)
-            self._target.end(Comment)
-else:
-    #just use the stock one
-    MeldParser = XMLParser
 
 class HTMLMeldParser(HTMLParser):
     """ A mostly-cut-and-paste of ElementTree's HTMLTreeBuilder that
@@ -879,7 +856,7 @@ def parse_xml(source):
     html is true, use a parser that can resolve somewhat ambiguous
     HTML into XHTML.  Otherwise use a 'normal' parser only."""
     builder = MeldTreeBuilder()
-    parser = MeldParser(target=builder)
+    parser = XMLParser(target=builder)
     return do_parse(source, parser)
 
 def parse_html(source, encoding=None):

--- a/meld3/_compat.py
+++ b/meld3/_compat.py
@@ -80,7 +80,7 @@ def _encode(s, encoding):
 
 def _raise_serialization_error(text):
     raise TypeError(
-        "cannot serialize %r (type %s)" % (text, type(text).__name__)
+        "cannot serialize {!r} (type {})".format(text, type(text).__name__)
         )
 
 _pattern = None
@@ -124,7 +124,7 @@ def fixtag(tag, namespaces):
             xmlns = ("xmlns:%s" % prefix, namespace_uri)
     else:
         xmlns = None
-    return "%s:%s" % (prefix, tag), xmlns
+    return "{}:{}".format(prefix, tag), xmlns
 #-----------------------------------------------------------------------------
 # End fork from Python 2.6.8 stdlib
 #-----------------------------------------------------------------------------

--- a/meld3/_compat.py
+++ b/meld3/_compat.py
@@ -21,11 +21,6 @@ except ImportError: # Python 3.x
 
 
 try:
-    bytes = bytes
-except NameError:   # Python 2.5
-    bytes = str
-
-try:
     unichr = unichr
 except NameError:   # Python 3.x
     unichr = chr

--- a/meld3/test_meld3.py
+++ b/meld3/test_meld3.py
@@ -324,7 +324,7 @@ class MeldAPITests(unittest.TestCase):
         self.assertEqual(item.tag, 'item')
         unknown = root.findmeld('unknown', 'foo')
         self.assertEqual(unknown, 'foo')
-        self.assertEqual(root.findmeld('unknown'), None)
+        self.assertIsNone(root.findmeld('unknown'))
 
     def test_repeat_nochild(self):
         root = self._makeElement(_SIMPLE_XML)
@@ -409,18 +409,18 @@ class MeldAPITests(unittest.TestCase):
         clone = root.clone()
         unfilled = clone.fillmeldhtmlform(**data[1])
         self.assertEqual(unfilled, ['favorite_color:inputgroup'])
-        self.assertEqual(clone.findmeld('over18').attrib.get('checked'), None)
+        self.assertIsNone(clone.findmeld('over18').attrib.get('checked'))
         mailok = clone.findmeld('mailok:inputgroup')
         self.assertEqual(mailok[2].attrib['checked'], 'checked')
-        self.assertEqual(mailok[1].attrib.get('checked'), None)
+        self.assertIsNone(mailok[1].attrib.get('checked'))
 
         clone = root.clone()
         unfilled = clone.fillmeldhtmlform(**data[2])
         self.assertEqual(sorted(unfilled), ['notthere', 'suffix'])
-        self.assertEqual(clone.findmeld('honorific').text, None)
+        self.assertIsNone(clone.findmeld('honorific').text)
         favoritecolor = clone.findmeld('favorite_color:inputgroup')
         self.assertEqual(favoritecolor[2].attrib['checked'], 'checked')
-        self.assertEqual(favoritecolor[1].attrib.get('checked'), None)
+        self.assertIsNone(favoritecolor[1].attrib.get('checked'))
 
     def test_replace_removes_all_elements(self):
         from . import Replace
@@ -469,7 +469,7 @@ class MeldAPITests(unittest.TestCase):
         self.assertEqual(len(N.getchildren()), 0)
         D = I[1]
         self.assertEqual(D.tag, 'description')
-        self.assertEqual(D.text, None)
+        self.assertIsNone(D.text)
         self.assertEqual(len(D.getchildren()), 1)
         T = D[0]
         self.assertEqual(T.tag, Replace)
@@ -594,7 +594,7 @@ class MeldElementInterfaceTests(unittest.TestCase):
 
     def test_ctor(self):
         iface = self._makeOne('div', {'id':'thediv'})
-        self.assertEqual(iface.parent, None)
+        self.assertIsNone(iface.parent)
         self.assertEqual(iface.tag, 'div')
         self.assertEqual(iface.attrib, {'id':'thediv'})
 
@@ -708,20 +708,20 @@ class MeldElementInterfaceTests(unittest.TestCase):
 
     def test_deparent_noparent(self):
         div = self._makeOne('div', {})
-        self.assertEqual(div.parent, None)
+        self.assertIsNone(div.parent)
         div.deparent()
-        self.assertEqual(div.parent, None)
+        self.assertIsNone(div.parent)
 
     def test_deparent_withparent(self):
         parent = self._makeOne('parent', {})
-        self.assertEqual(parent.parent, None)
+        self.assertIsNone(parent.parent)
         child = self._makeOne('child', {})
         parent.append(child)
-        self.assertEqual(parent.parent, None)
+        self.assertIsNone(parent.parent)
         self.assertEqual(child.parent, parent)
         self.assertEqual(parent[0], child)
         child.deparent()
-        self.assertEqual(child.parent, None)
+        self.assertIsNone(child.parent)
         self.assertRaises(IndexError, parent.__getitem__, 0)
 
     def test_setslice(self):
@@ -744,8 +744,8 @@ class MeldElementInterfaceTests(unittest.TestCase):
         children = (child1, child2, child3)
         parent[0:2] = children
         del parent[0:2]
-        self.assertEqual(child1.parent, None)
-        self.assertEqual(child2.parent, None)
+        self.assertIsNone(child1.parent)
+        self.assertIsNone(child2.parent)
         self.assertEqual(child3.parent, parent)
         self.assertEqual(len(parent._children), 1)
 
@@ -754,7 +754,7 @@ class MeldElementInterfaceTests(unittest.TestCase):
         child1 = self._makeOne('child1', {})
         parent.append(child1)
         parent.remove(child1)
-        self.assertEqual(child1.parent, None)
+        self.assertIsNone(child1.parent)
         self.assertEqual(len(parent._children), 0)
 
     def test_lineage(self):
@@ -1112,7 +1112,7 @@ class ParserTests(unittest.TestCase):
         from . import _MELD_ID
         root = self._parse(_SIMPLE_XML)
         self.assertEqual(root.tag, 'root')
-        self.assertEqual(root.parent, None)
+        self.assertIsNone(root.parent)
         l1st = root[0]
         self.assertEqual(l1st.tag, 'list')
         self.assertEqual(l1st.parent, root)
@@ -1137,7 +1137,7 @@ class ParserTests(unittest.TestCase):
         root = self._parse(_SIMPLE_XHTML)
         self.assertEqual(root.tag, xhtml_ns % 'html')
         self.assertEqual(root.attrib, {})
-        self.assertEqual(root.parent, None)
+        self.assertIsNone(root.parent)
         body = root[0]
         self.assertEqual(body.tag, xhtml_ns % 'body')
         self.assertEqual(body.attrib[_MELD_ID], 'body')
@@ -1149,7 +1149,7 @@ class ParserTests(unittest.TestCase):
         root = self._parse(_COMPLEX_XHTML)
         self.assertEqual(root.tag, xhtml_ns % 'html')
         self.assertEqual(root.attrib, {})
-        self.assertEqual(root.parent, None)
+        self.assertIsNone(root.parent)
         head = root[0]
         self.assertEqual(head.tag, xhtml_ns % 'head')
         self.assertEqual(head.attrib, {})
@@ -1223,7 +1223,7 @@ class ParserTests(unittest.TestCase):
         root = self._parse_html(_NVU_HTML)
         self.assertEqual(root.tag, 'html')
         self.assertEqual(root.attrib, {})
-        self.assertEqual(root.parent, None)
+        self.assertIsNone(root.parent)
         head = root[0]
         self.assertEqual(head.tag, 'head')
         self.assertEqual(head.attrib, {})

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ import sys
 
 py_version = sys.version_info[:2]
 
-if py_version < (2, 5):
-    raise RuntimeError('On Python 2, meld3 requires Python 2.5 or later')
-elif (3, 0) < py_version < (3, 2):
-    raise RuntimeError('On Python 3, meld3 requires Python 3.2 or later')
+if py_version < (2, 7):
+    raise RuntimeError('On Python 2, meld3 requires Python 2.7')
+elif (3, 0) < py_version < (3, 4):
+    raise RuntimeError('On Python 3, meld3 requires Python 3.4 or later')
 
 install_requires = []
 
@@ -16,12 +16,8 @@ CLASSIFIERS = [
     'Intended Audience :: Developers',
     'Operating System :: POSIX',
     'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.5',
-    'Programming Language :: Python :: 2.6',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.2',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    pypy,py25,py26,py27,py32,py33,py34,py35,py36
+    pypy,py27,py34,py35,py36
 
 [testenv]
 commands =


### PR DESCRIPTION
https://github.com/Supervisor/supervisor says:

> Supervisor 4.0 (unreleased) is designed to work under Python 3 version 3.4 or later and on Python 2 version 2.7.

Update meld3 to also remove those EOL versions.

See also https://github.com/Supervisor/superlance/pull/112.